### PR TITLE
Fesom cavity freshwaterflux as icebergs

### DIFF
--- a/fesom_icb_pism/plugin.py
+++ b/fesom_icb_pism/plugin.py
@@ -64,6 +64,14 @@ def update_icebergs(config):
         print(" * use scaling factors ", scaling_factor)
         bcavities = config["fesom"].get("use_cav", False)
 
+        # New parameters for FESOM input type
+        # input_type: "pism" (default, original PISM discharge) or "fesom" (FESOM cavity freshwater flux)
+        input_type = config["fesom"].get("icb_input_type", "pism")
+        # mesh_diag_file: path to fesom.mesh.diag.nc (defaults to mesh_dir + 'fesom.mesh.diag.nc')
+        mesh_diag_file = config["fesom"].get("mesh_diag_file", mesh_dir)
+        print(f" * icb_input_type = {input_type}")
+        print(f" * mesh_diag_file = {mesh_diag_file}")
+
         if isinstance(disch_file, list) and isinstance(basin_file, list):
             if len(disch_file) == len(basin_file):
                 domain = config["fesom"].get("domain", "sh")
@@ -80,6 +88,8 @@ def update_icebergs(config):
                         ibareamax=config["fesom"].get("ibareamax", 400),
                         domain=dom, #config["fesom"].get("domain", "sh"),
                         bcavities=bcavities,
+                        input_type=input_type,
+                        mesh_diag_file=mesh_diag_file,
                     )
                     ib.create_dataframe()
                     ib._icb_generator(fmode=fmode)
@@ -98,6 +108,8 @@ def update_icebergs(config):
                 seed=int(str(config["general"]["current_date"].year) + str(config["general"]["current_date"].month)), 
                 ibareamax=config["fesom"].get("ibareamax", 400),
                 bcavities=bcavities,
+                input_type=input_type,
+                mesh_diag_file=mesh_diag_file,
             )
             ib.create_dataframe()
             ib._icb_generator(fmode="w")


### PR DESCRIPTION
@ackerlar, I added a feature to the plugin to accept a fesom freshwater flux ```fw.fesom.<year>.nc``` in addition to the PISM ```latest_discharge.nc``` file. As discussed with you and Jan, the idea here is to add the cavity mass loss of the previous simulation year as icebergs in the subsequent year, in order to maintain a 50:50 balance between them, while switching the oIFS solid runoff from Antarctica off.

From the freshwater flux, only the flux in the cavity is computed and converted to the expected m3/y of ice per grid cell. 

The conversion is executed by:
``` freshwater flux [m/s] * grid_cell_area [m2] * rho_water/rho_ice * seconds_per_year [s/y] = ice_flux [m3/y]```

Afterwards, the basin assignment, using a basin nc file such as ```antarctica.16km.nc```, of the individual fesom grid cells takes over without any modifications.

I also added the additional runscript fesom parameters to be read by the plugin
```
fesom:
    input_type: 'fesom' # or 'pism'
    mesh_diag_file: '<path to fesom.mesh.diag.nc>' # default is to fesom.mesh_dir + 'fesom.mesh.diag.nc'
```

The ```mesh.diag.nc``` file is needed for fesom's nodal areas for the flux conversion.

I ran some offline tests, not yet with esm_tools, and the modifications gave good results.
[antarctica_iceberg_locations.pdf](https://github.com/user-attachments/files/24667668/antarctica_iceberg_locations.pdf)

If it is cleaner, I could also separate the fesom case to an independent esm-tools-plugin.

One thing which I am not sure how to accomplish is make esm-tools copy the freshwater file from the previous run to the current work so it can be accessed by the plugin.
